### PR TITLE
Set `contextIsolation` to `false` for Electron 12.0.0^

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,8 @@ function spawnWindow(){
 		blurCornerRadius: 20,
 		vibrancy: "fullscreen-ui",
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+            		contextIsolation: false
 		}
 	});
 	


### PR DESCRIPTION
Tested on Electron [12.0.9](https://www.electronjs.org/releases/stable?version=12#12.0.9) and [13.0.0](https://www.electronjs.org/releases/stable#13.0.0) on Windows 10 21H1.

Without [`contextIsolation`](https://www.electronjs.org/docs/tutorial/context-isolation) set to `false`, the following error will occur:
```
require()' is not defined.
```
