### PR TITLE
Remove white tint for Window 11 #150

### DIFF
--- a/src/native/win32_dwm/dwm.js
+++ b/src/native/win32_dwm/dwm.js
@@ -60,7 +60,7 @@ module.exports = class DWM{
 		return this.setWindowCompositionAttribute(3, tint);
 	}
 
-	setAcrylic(tint = 0x00ffffff){
+	setAcrylic(tint = 0x00404040){
 		if(!this.supportsAcrylic()) return this.setBlurBehind(tint);
 		return this.setWindowCompositionAttribute(4, tint);
 	}


### PR DESCRIPTION
Note that this hasn't been tested on Windows 10.

Preview on Windows 11:
![image](https://user-images.githubusercontent.com/51213244/135960103-b234cf3d-ef67-4bd5-b6c1-5a8e75d983bc.png)